### PR TITLE
Clone without checkout

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var execFileP = pify(childProcess.execFile.bind(childProcess), Promise);
 var conf = new Configstore(pkg.name);
 
 function clone(repo, dest) {
-	return execFileP('git', ['clone', '--template=""', 'https://github.com/' + repo + '.git', dest], {stdio: 'ignore'});
+	return execFileP('git', ['clone', '--no-checkout', '--template=""', 'https://github.com/' + repo + '.git', dest], {stdio: 'ignore'});
 }
 
 function extractOffset(push, dir) {


### PR DESCRIPTION
This patch adds `--no-checkout` option to `git` so that it doesn't perform a tree checkout after cloning. Since all we need is log we should save time and memory on useless file system operations.

``` fish
$ ./cli.js indutny
16:41 - 17 Feb. 2016
> 127445
```

It's still a lot of time (2 min), but at least it works on my machine [when it previously didn't](https://github.com/SamVerschueren/dev-time/issues/6#issuecomment-185412656).

`--no-checkout` saves a lot of precious memory/disk space: for the Node.js example above it took only ~150M this time, and fully unpacked Node.js repo ~~is around 2.8G~~ (these were as I turns out mostly build artifacts) is 393M — which is more that 2.5x.
