### PR TITLE
Remove dev-time.today from related section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,6 @@ Can be set globally with the `GITHUB_TOKEN` environment variable.
 ## Related
 
 - [dev-time-cli](https://github.com/SamVerschueren/dev-time-cli) - CLI for this module
-- http://dev-time.today - Website for this module
 
 
 ## License


### PR DESCRIPTION
The domain is no longer registered. /cc @stevemao (who built the website)